### PR TITLE
handle overscroll with a default background color

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -2,6 +2,8 @@
 
 body {
   font-family: $font-family;
+  background-color: $bg-color;
+  overscroll-behavior-y: none;
   width: 100vw;
   min-height: 100vh;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -7,7 +7,7 @@
 
 $bg-color: #15173d;
 $bg-color-light: #1d2056;
-$bg-color-lighter: #3F46BC;
+$bg-color-lighter: #3f46bc;
 $primary: #e07a30;
 $primary-dark: #dd5227;
 $white: #ffffff;


### PR DESCRIPTION
On macos device and some navigators, an overscroll on top of the page is creating a default white content disgracefull...
This PR is here to fix and/or handle this stuff.

![Screenshot 2025-04-09 at 10 04 39](https://github.com/user-attachments/assets/46f8bfc0-1e31-44b7-b3aa-9b7a2bc24b73)

